### PR TITLE
set mysql password only when password is empty

### DIFF
--- a/cookbooks/percona/recipes/server.rb
+++ b/cookbooks/percona/recipes/server.rb
@@ -23,7 +23,8 @@ service "mysql" do
 end
 
 execute 'set-mysql-root' do
-	command "mysqladmin -u root password #{node['mysql']['server_root_password']}"
+    command "mysqladmin -u root password #{node['mysql']['server_root_password']}"
+    only_if "/usr/bin/mysql -u root -e 'show databases;'"
 end
 
 template "/etc/mysql/my.cnf" do


### PR DESCRIPTION
If executing these recipes over 2 times, the function of setting mysql password failed.
so I've made a patch. thank you.
