### PR TITLE
Clarifications on how `vagrant-chef` relates to a CakePHP project

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -127,6 +127,12 @@ To set up and run a virtual machine, simply run this command from the folder whe
 vagrant up
 ```
 
+Alternatively, if you would like to make use of [Vagrant Cloud](https://vagrantcloud.com/), you can simply run the following.
+
+```bash
+vagrant init friendsofcake/cakephp-baking
+```
+
 It may take a bit to download the Vagrant box, but once that is done, you will be prompted for your laptop password. This is so we can properly expose the IP of the vagrant instance to your machine. Type in your password and let it continue running.
 
 You can grab a coffee or go out for a beer at this point. Takes about half an hour to an hour, depending upon your internet connection and laptop resources.


### PR DESCRIPTION
The readme was sugesting cloning the repo, which created a `.git` folder of `vagrant-chef`, which in turn made me think that my project's code (and it's own `.git` folder) should be put somewhere else.

I've made it clear that `vagrant-chef`'s files should be added to project source.

I've changed the `git clone` command with this one:

``` bash
wget https://github.com/FriendsOfCake/vagrant-chef/archive/master.tar.gz -O - | tar -xz --strip-components 1
```

It will download the source code of `vagrant-chef` into current folder without creating a local `.git` repo. It can be used both for existing project and for a blank folder (provided that you `mkdir` and `cd` first).
