### PR TITLE
Implements user settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,12 @@
 *
 
 # but not these files
-cookbooks
-.gitignore
-.ruby-version
-.travis.yml
-Gemfile
-Gemfile.lock
-README.markdown
-Vagrantfile
+!cookbooks
+!.gitignore
+!.ruby-version
+!.travis.yml
+!Gemfile
+!Gemfile.lock
+!README.markdown
+!Vagrantfile
 !vagrant.yml.default

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Gemfile
 Gemfile.lock
 README.markdown
 Vagrantfile
+!vagrant.yml.default

--- a/README.markdown
+++ b/README.markdown
@@ -77,22 +77,18 @@ MySQL is available at `0.0.0.0:3306` with either of the following credentials:
 When you want to use vagrant instance for a development environment, you can create an `app` directory with the contents of your application. Within the vm, this would be an example of your directory structure:
 
     |-/vagrant/app
-    |-/vagrant/app/app
     | |-/vagrant/app/app/Config
     | |-/vagrant/app/app/Console
     | |-/vagrant/app/app/Controller
-    | |-/vagrant/app/app/Lib
     | |-/vagrant/app/app/Model
-    | |-/vagrant/app/app/Plugin
-    | |-/vagrant/app/app/tmp
-    | |-/vagrant/app/app/vendor
+    | |-/vagrant/app/app/Test
     | |-/vagrant/app/app/View
-    | |-/vagrant/app/app/webroot
-    |-/vagrant/app/lib
-    |-/vagrant/app/Plugin
-    |-/vagrant/app/vendor
+    | |-/vagrant/app/Plugin
+    | |-/vagrant/app/tmp
+    | |-/vagrant/app/vendor
+    | |-/vagrant/app/webroot
 
-Anything in `app/app/webroot/index.php` will be served up, and all other `index.php` files ignored.
+Anything in `app/webroot/index.php` will be served up, and all other `index.php` files ignored.
 
 Note, we recommend using the [FriendsOfCake/app-template](https://github.com/FriendsOfCake/app-template) for new applications.
 

--- a/README.markdown
+++ b/README.markdown
@@ -96,6 +96,13 @@ Anything in `app/app/webroot/index.php` will be served up, and all other `index.
 
 Note, we recommend using the [FriendsOfCake/app-template](https://github.com/FriendsOfCake/app-template) for new applications.
 
+## Configuration
+
+Even though the default server settings should suffice in most situations vagrant-chef offers a method to override some of them. Simply create an `vagrant.yml` configuration file and use one of the following options:
+
+- `app: name`: changes the servername used to connect to your app (e.g. api.domain.local)
+- `vm: ip_address`: changes the ip-address used to connect to your server
+
 ## Starting/Stopping Work
 
 You normally wont want to have the instance running full time. To pause it, simply perform the following in the command line:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,6 +64,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :chef_solo do |chef|
     chef.cookbooks_path = "cookbooks"
     chef.roles_path = "cookbooks/roles"
+    chef.json = {"vconfig" => vconfig}
     chef.add_role("vagrant")
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,9 +44,20 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_agent = true
 
+# Load configuration
+  vconfig = {
+    "app" => {
+      "name" => "app.dev"
+    },
+    "vm" => {
+      "ip_address" => "192.168.13.37"
+    }
+  }
+  vconfig = vconfig.merge(YAML::load_file("vagrant.yml")) if File.exist?("vagrant.yml")
+
   config.vm.box = "precise32"
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
-  config.vm.network "private_network", ip: "192.168.13.37"
+  config.vm.network "private_network", ip: vconfig['vm']['ip_address']
   config.vm.synced_folder ".", "/vagrant"
   config.vm.provision :shell, inline: $script
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,15 +44,8 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_agent = true
 
-# Load configuration
-  settings = {
-    "app" => {
-      "name" => "app.dev"
-    },
-    "vm" => {
-      "ip_address" => "192.168.13.37"
-    }
-  }
+  # Load configuration
+  settings = YAML::load_file("vagrant.yml.default")
   settings = settings.merge(YAML::load_file("vagrant.yml")) if File.exist?("vagrant.yml")
 
   config.vm.box = "precise32"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_agent = true
 
   # Load configuration
+  raise Vagrant::Errors::VagrantError.new, "Error: configuration file vagrant.yml.default not found" unless File.exist?("vagrant.yml.default")
   settings = YAML::load_file("vagrant.yml.default")
   settings = settings.merge(YAML::load_file("vagrant.yml")) if File.exist?("vagrant.yml")
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_agent = true
 
 # Load configuration
-  vconfig = {
+  settings = {
     "app" => {
       "name" => "app.dev"
     },
@@ -53,18 +53,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "ip_address" => "192.168.13.37"
     }
   }
-  vconfig = vconfig.merge(YAML::load_file("vagrant.yml")) if File.exist?("vagrant.yml")
+  settings = settings.merge(YAML::load_file("vagrant.yml")) if File.exist?("vagrant.yml")
 
   config.vm.box = "precise32"
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
-  config.vm.network "private_network", ip: vconfig['vm']['ip_address']
+  config.vm.network "private_network", ip: settings['vm']['ip_address']
   config.vm.synced_folder ".", "/vagrant"
   config.vm.provision :shell, inline: $script
 
   config.vm.provision :chef_solo do |chef|
     chef.cookbooks_path = "cookbooks"
     chef.roles_path = "cookbooks/roles"
-    chef.json = {"vconfig" => vconfig}
+    chef.json = {"foc" => settings}
     chef.add_role("vagrant")
   end
 

--- a/cookbooks/nginx/attributes/default.rb
+++ b/cookbooks/nginx/attributes/default.rb
@@ -15,4 +15,4 @@ default['nginx']['gzip_types'] = [
   "image/jpeg"
 ]
 
-default['nginx']['server_name'] = 'app.dev'
+default['nginx']['server_name'] = node['foc']['app']['name']

--- a/cookbooks/nginx/recipes/server.rb
+++ b/cookbooks/nginx/recipes/server.rb
@@ -41,12 +41,24 @@ template "/etc/nginx/nginx.conf" do
 end
 
 template "/etc/nginx/sites-available/default" do
-  source "app.dev.erb"
+  source "default.erb"
+  owner "root"
+  group "root"
+  mode 0644
+  notifies :restart, "service[nginx]"
+end
+
+template "/etc/nginx/sites-available/default.dev" do
+  source "default.dev.erb"
   owner "root"
   group "root"
   mode 0644
   variables(
-    :server_name => node['nginx']['server_name']
+    :server_name => node['foc']['app']['name']
   )
   notifies :restart, "service[nginx]"
+end
+
+link "/etc/nginx/sites-enabled/default.dev" do
+  to "/etc/nginx/sites-available/default.dev"
 end

--- a/cookbooks/nginx/templates/default/default.dev.erb
+++ b/cookbooks/nginx/templates/default/default.dev.erb
@@ -1,7 +1,7 @@
 server {
 	listen 80;
 	server_name <%= @server_name %>;
-	root /vagrant/app/app/webroot;
+	root /vagrant/app/webroot;
 	access_log /var/log/nginx/<%= @server_name %>-access.log;
 
 	index index.php index.html;

--- a/cookbooks/nginx/templates/default/default.dev.erb
+++ b/cookbooks/nginx/templates/default/default.dev.erb
@@ -1,7 +1,7 @@
 server {
 	listen 80;
 	server_name <%= @server_name %>;
-	root /vagrant/app/webroot;
+	root /vagrant/app/app/webroot;
 	access_log /var/log/nginx/<%= @server_name %>-access.log;
 
 	index index.php index.html;

--- a/cookbooks/nginx/templates/default/default.erb
+++ b/cookbooks/nginx/templates/default/default.erb
@@ -1,6 +1,6 @@
 server {
 	listen   80; ## listen for ipv4; this line is default and implied
-	root /usr/share/nginx/www;
+	root /usr/share/nginx/html;
 	index index.html index.htm;
 	server_name localhost;
 

--- a/vagrant.yml.default
+++ b/vagrant.yml.default
@@ -1,0 +1,9 @@
+# FriendsOfCake
+#
+# Override default vagrant-chef settings
+---
+app:
+  name: app.dev
+
+vm:
+  ip_address: 10.36.2.10

--- a/vagrant.yml.default
+++ b/vagrant.yml.default
@@ -6,4 +6,4 @@ app:
   name: app.dev
 
 vm:
-  ip_address: 10.36.2.10
+  ip_address: 192.168.13.37


### PR DESCRIPTION
Adds user configuration.

- non-obtrusive:
	- uses the default settings in Vagrantfile
	- only overrides if vagrant.yml is found
	- this way simply running `vagrant up` still works
- exposes all settings as chef attributes so they can be consistently used in the cookbooks (e.g. `node['foc']['app']['name']`)
- can be tested/used by changing `ip_address` 

I have deliberately kept the .default template small to get this PR passed but things could easily be expanded so we can work towards something like:

	app:
      name: api.domain.local
	  app_template: cake3

	vm:
      hostname: foc01
      ip_address: 10.36.2.10
      share_app_folder: true

Tested successfully with full rebuild.