### PR TITLE
Enable mcrypt through symlink. Closes #33

### DIFF
--- a/cookbooks/php/recipes/install.rb
+++ b/cookbooks/php/recipes/install.rb
@@ -26,6 +26,14 @@
   end
 end
 
+link "/etc/php5/cli/conf.d/mcrypt.ini" do
+  to "/etc/php5/mods-available/mcrypt.ini"
+end
+
+link "/etc/php5/fpm/conf.d/mcrypt.ini" do
+  to "/etc/php5/mods-available/mcrypt.ini"
+end
+
 service "php5-fpm" do
   action :nothing
 end


### PR DESCRIPTION
The extension is somehow not enabled by default, so we need to symlink it manually.