### PR TITLE
pass to fallback on try_files failed

### DIFF
--- a/cookbooks/nginx/templates/default/app.dev.erb
+++ b/cookbooks/nginx/templates/default/app.dev.erb
@@ -16,7 +16,7 @@ server {
   }
 
   location / {
-    try_files $uri $uri/ /index.php?$args = @fallback;
+    try_files $uri $uri/ /index.php?$args @fallback;
     expires max;
     access_log on;
   }

--- a/cookbooks/nginx/templates/default/app.dev.erb
+++ b/cookbooks/nginx/templates/default/app.dev.erb
@@ -16,7 +16,7 @@ server {
   }
 
   location / {
-    try_files $uri $uri/ /index.php?$args;
+    try_files $uri $uri/ /index.php?$args = @fallback;
     expires max;
     access_log on;
   }


### PR DESCRIPTION
## What I did and what I got

```
$ curl http://192.168.13.37/
No input file specified.
```

```
$ cat /var/log/nginx/error.log
2015/08/31 18:12:55 [error] 27657#0: *1 FastCGI sent in stderr: "Primary script unknown" while reading response header from upstream, client: 192.168.13.1, server: app.dev, request: "GET /index.html HTTP/1.1", upstream: "fastcgi://unix:/var/run/php5-fpm.sock:", host: "192.168.13.37"
```


## Env

```
$ git show
commit 59653e26e70d9221397d89f811aa006ac9871a24
[snip]
```

Same to https://github.com/FriendsOfCake/vagrant-chef/issues/41 except HEAD rivision.