### PR TITLE
Fix example of directory structure on README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,7 +90,7 @@ When you want to use vagrant instance for a development environment, you can cre
     | |-/vagrant/app/app/Model
     | |-/vagrant/app/app/Plugin
     | |-/vagrant/app/app/tmp
-    | |-/vagrant/app/app/vendor
+    | |-/vagrant/app/app/Vendor
     | |-/vagrant/app/app/View
     | |-/vagrant/app/app/webroot
     |-/vagrant/app/lib

--- a/README.markdown
+++ b/README.markdown
@@ -92,12 +92,12 @@ When you want to use vagrant instance for a development environment, you can cre
     | |-/vagrant/app/app/tmp
     | |-/vagrant/app/app/Vendor
     | |-/vagrant/app/app/View
-    | |-/vagrant/app/app/webroot
+    |-/vagrant/app/webroot
     |-/vagrant/app/lib
     |-/vagrant/app/plugin
     |-/vagrant/app/vendor
 
-Anything in `app/app/webroot/index.php` will be served up, and all other `index.php` files ignored.
+Anything in `app/webroot/index.php` will be served up, and all other `index.php` files ignored.
 
 Note, we recommend using the [FriendsOfCake/app-template](https://github.com/FriendsOfCake/app-template) for new applications.
 

--- a/README.markdown
+++ b/README.markdown
@@ -89,9 +89,9 @@ When you want to use vagrant instance for a development environment, you can cre
     | |-/vagrant/app/app/Lib
     | |-/vagrant/app/app/Model
     | |-/vagrant/app/app/Plugin
-    | |-/vagrant/app/app/tmp
     | |-/vagrant/app/app/Vendor
     | |-/vagrant/app/app/View
+    |-/vagrant/app/tmp
     |-/vagrant/app/webroot
     |-/vagrant/app/lib
     |-/vagrant/app/plugin

--- a/README.markdown
+++ b/README.markdown
@@ -94,7 +94,7 @@ When you want to use vagrant instance for a development environment, you can cre
     | |-/vagrant/app/app/View
     | |-/vagrant/app/app/webroot
     |-/vagrant/app/lib
-    |-/vagrant/app/Plugin
+    |-/vagrant/app/plugin
     |-/vagrant/app/vendor
 
 Anything in `app/app/webroot/index.php` will be served up, and all other `index.php` files ignored.


### PR DESCRIPTION
> ```
> server {
>   listen 80;
>   server_name <%= @server_name %>;
>   root /vagrant/app/webroot;
> ```
> https://github.com/FriendsOfCake/vagrant-chef/blob/master/cookbooks/nginx/templates/default/app.dev.erb#L4

Fix to suite this line of config.