### PR TITLE
Revert "pass to fallback on try_files failed"

### DIFF
--- a/cookbooks/nginx/templates/default/app.dev.erb
+++ b/cookbooks/nginx/templates/default/app.dev.erb
@@ -16,7 +16,7 @@ server {
   }
 
   location / {
-    try_files $uri $uri/ /index.php?$args @fallback;
+    try_files $uri $uri/ /index.php?$args;
     expires max;
     access_log on;
   }


### PR DESCRIPTION
Reverts FriendsOfCake/vagrant-chef#42

Sorry, I made a mistake.
That prevents access to image, css, js on theme.

I have fighting to get `It works!` page just after the setup.
But I could not find how to redirect if folder is not exist that is indicated `root` derective.
I give up.