### PR TITLE
Custom box for parallels is not needed now

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,7 +72,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provider :parallels do |v, override|
-    override.vm.box = "parallels/ubuntu-14.04"
     v.memory = 1024
     v.cpus = 1
   end


### PR DESCRIPTION
In this commit 59653e2 box is changed to bento, which include parallels image, so custom box for parallels is not needed.