### PR TITLE
Install php extension simplexml

### DIFF
--- a/cookbooks/php/recipes/install.rb
+++ b/cookbooks/php/recipes/install.rb
@@ -19,6 +19,7 @@ include_recipe "php::apt_repository"
   "php7.0-mysql",
   "php7.0-pgsql",
   "php7.0-redis",
+  "php7.0-simplexml",
   "php7.0-sqlite",
   "php7.0-xdebug",
   "php7.0-zip",


### PR DESCRIPTION
When creating a project that installs "cakephp/cakephp-codesniffer", ext-simplexml is required. It seems like this isn't enabled by default in php7, as it was with php5.x.