### PR TITLE
Make www-data owner of nginx log folder

### DIFF
--- a/cookbooks/nginx/recipes/server.rb
+++ b/cookbooks/nginx/recipes/server.rb
@@ -63,3 +63,8 @@ link "/etc/nginx/sites-enabled/apps" do
   to "/etc/nginx/sites-available/apps"
   notifies :reload, "service[nginx]"
 end
+
+directory '/var/log/nginx' do
+  owner "www-data"
+  group "www-data"
+end


### PR DESCRIPTION
In order to create log files on the fly when using multiple apps, www-data need ownership of logging folder. This fixes https://github.com/FriendsOfCake/vagrant-chef/issues/62