### PR TITLE
Make default config-file load first

### DIFF
--- a/cookbooks/nginx/recipes/server.rb
+++ b/cookbooks/nginx/recipes/server.rb
@@ -59,7 +59,7 @@ template "/etc/nginx/sites-available/apps" do
   notifies :reload, "service[nginx]"
 end
 
-link "/etc/nginx/sites-enabled/apps" do
+link "/etc/nginx/sites-enabled/multiple-apps" do
   to "/etc/nginx/sites-available/apps"
   notifies :reload, "service[nginx]"
 end


### PR DESCRIPTION
Nginx loads config files in sites-enabled in sorted order. This makes "apps" load before "default". Server directives in "default" will never be reached, since they are covered in the "apps" conf as well. By renaming the linked file to "multiple-apps", "default" will be loaded first, and can serve up anything in the app-dir correctly, even when accessing 192.168.13.37
This solves the problem in https://github.com/FriendsOfCake/vagrant-chef/issues/58